### PR TITLE
Create responsive phone verification site

### DIFF
--- a/analysis.html
+++ b/analysis.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Analisando Número</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Analisando o número <span id="number-span"></span>...</h1>
+    <div class="loader"></div>
+    <ul class="tips">
+      <li><i class="fas fa-shield-alt"></i> Proteja seu código.</li>
+      <li><i class="fas fa-user-secret"></i> Mantenha dados seguros.</li>
+      <li><i class="fas fa-lock"></i> Verifique permissões de SMS.</li>
+    </ul>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verificação de Número</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+</head>
+<body>
+  <div class="container">
+    <div class="card">
+      <i class="fas fa-mobile-alt icon-large"></i>
+      <h1>Verifique seu Número de Celular</h1>
+      <p class="subtitle">Digite o número no formato <strong>(DDD) 99999-9999</strong></p>
+      <form id="verify-form">
+        <div class="input-group">
+          <i class="fas fa-phone"></i>
+          <input type="text" id="phone" placeholder="(DDD) 99999-9999" required>
+        </div>
+        <p id="error-message" class="error-message"><i class="fas fa-exclamation-triangle"></i> Formato inválido. Use (DDD) 99999-9999.</p>
+        <button type="submit" class="btn-primary"><i class="fas fa-phone"></i> Iniciar Verificação <i class="fas fa-arrow-right"></i></button>
+      </form>
+      <p class="info"><i class="fas fa-shield-alt"></i> Seu número é usado apenas para fins de demonstração. Garantimos privacidade.</p>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/results.html
+++ b/results.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Resultados</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Resultados da Verificação</h1>
+    <div class="summary">
+      <i class="fas fa-user icon-large"></i>
+      <p>Número: <span id="numero-consultado"></span></p>
+    </div>
+    <div class="grid">
+      <div class="info-card">
+        <i class="fas fa-signal"></i>
+        <h3>Operadora</h3>
+        <p>Vivo</p>
+      </div>
+      <div class="info-card">
+        <i class="fas fa-map-marker-alt"></i>
+        <h3>Localização</h3>
+        <p>São Paulo - SP</p>
+      </div>
+      <div class="info-card">
+        <i class="fas fa-check-circle"></i>
+        <h3>Status</h3>
+        <p>Ativo</p>
+      </div>
+      <div class="info-card">
+        <i class="fas fa-calendar-alt"></i>
+        <h3>Última Verificação</h3>
+        <p>Hoje</p>
+      </div>
+    </div>
+    <div class="espionagem">
+      <h2><i class="fas fa-user-secret"></i> Informações sobre Espionagem</h2>
+      <p>A espionagem de smartphones pode envolver rastreamento de chamadas, acesso a mensagens e localização em tempo real. Em cenários de teste, exibimos dados fictícios para demonstrar as possibilidades.</p>
+      <ul class="spy-list">
+        <li><i class="fas fa-map-marker-alt"></i> Rastreio de localização aproximada.</li>
+        <li><i class="fas fa-comments"></i> Monitoramento de mensagens (WhatsApp, SMS).</li>
+        <li><i class="fas fa-camera"></i> Captura simulada de imagem via câmera frontal.</li>
+        <li><i class="fas fa-microphone"></i> Gravação simulada de áudio ambiente.</li>
+      </ul>
+    </div>
+    <button id="new-query" class="btn-secondary"><i class="fas fa-redo-alt"></i> Nova Consulta</button>
+    <p class="disclaimer">Informações fornecidas apenas para fins de teste. Dados fictícios.</p>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,44 @@
+function initIndex() {
+  const form = document.getElementById('verify-form');
+  if (!form) return;
+  const input = document.getElementById('phone');
+  const error = document.getElementById('error-message');
+  form.addEventListener('submit', function (e) {
+    e.preventDefault();
+    const value = input.value.trim();
+    const regex = /^\(\d{2}\) \d{5}-\d{4}$/;
+    if (!regex.test(value)) {
+      error.style.display = 'block';
+      return;
+    }
+    error.style.display = 'none';
+    window.location.href = 'analysis.html?numero=' + encodeURIComponent(value);
+  });
+}
+
+function initAnalysis() {
+  const span = document.getElementById('number-span');
+  if (!span) return;
+  const params = new URLSearchParams(window.location.search);
+  const numero = params.get('numero') || '';
+  span.textContent = numero;
+  setTimeout(function () {
+    window.location.href = 'results.html?numero=' + encodeURIComponent(numero);
+  }, 15000);
+}
+
+function initResults() {
+  const span = document.getElementById('numero-consultado');
+  if (!span) return;
+  const params = new URLSearchParams(window.location.search);
+  const numero = params.get('numero') || '';
+  span.textContent = numero;
+  const btn = document.getElementById('new-query');
+  if (btn) btn.addEventListener('click', () => { window.location.href = 'index.html'; });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  initIndex();
+  initAnalysis();
+  initResults();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,207 @@
+:root {
+  --cor-primaria: #0066cc;
+  --cor_secundaria: #28a745;
+  --cor_fundo_light: #f9f9f9;
+  --cor_texto_principal: #333333;
+  --cor_texto_secundario: #666666;
+}
+
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&family=Montserrat:wght@300;400;700&display=swap');
+
+body {
+  margin: 0;
+  font-family: 'Montserrat', sans-serif;
+  background: var(--cor_fundo_light);
+  color: var(--cor_texto_principal);
+}
+
+h1, h2, h3 {
+  font-family: 'Poppins', sans-serif;
+  font-weight: 600;
+  margin: 0 0 10px 0;
+}
+
+.container {
+  max-width: 480px;
+  margin: 40px auto;
+  padding: 20px;
+}
+
+.card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  padding: 20px;
+  text-align: center;
+}
+
+.icon-large {
+  font-size: 48px;
+  color: var(--cor-primaria);
+  margin-bottom: 10px;
+}
+
+.subtitle {
+  color: var(--cor_texto_secundario);
+}
+
+.input-group {
+  position: relative;
+  margin: 20px 0;
+}
+.input-group i {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--cor_texto_secundario);
+}
+.input-group input {
+  width: 100%;
+  padding: 10px 10px 10px 36px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 16px;
+}
+
+.error-message {
+  display: none;
+  color: red;
+  font-size: 14px;
+  text-align: left;
+}
+.error-message i {
+  margin-right: 6px;
+}
+
+.btn-primary, .btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.3s ease;
+}
+
+.btn-primary { background: var(--cor-primaria); }
+.btn-primary:hover { background: #005bb5; }
+
+.btn-secondary { background: var(--cor_secundaria); }
+.btn-secondary:hover { background: #218838; }
+
+.info {
+  font-size: 14px;
+  color: var(--cor_texto_secundario);
+  margin-top: 15px;
+}
+
+.loader {
+  width: 80px;
+  height: 80px;
+  border: 10px solid #ddd;
+  border-top: 10px solid var(--cor-primaria);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 20px auto;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.tips {
+  list-style: none;
+  padding: 0;
+  margin: 20px 0 0 0;
+}
+.tips li {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  color: var(--cor_texto_secundario);
+}
+.tips li i { margin-right: 8px; color: var(--cor-primaria); }
+
+.summary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.info-card {
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 15px;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+.info-card i {
+  font-size: 32px;
+  color: var(--cor-primaria);
+  margin-bottom: 10px;
+}
+.info-card h3 {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 600;
+  margin-bottom: 5px;
+}
+
+.espionagem {
+  background: var(--cor_fundo_light);
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+.espionagem h2 {
+  display: flex;
+  align-items: center;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+.espionagem h2 i { margin-right: 8px; color: var(--cor-primaria); }
+
+.spy-list {
+  list-style: none;
+  padding-left: 0;
+}
+.spy-list li {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  color: var(--cor_texto_secundario);
+}
+.spy-list li i { margin-right: 8px; color: var(--cor-primaria); }
+
+.disclaimer {
+  font-size: 14px;
+  color: var(--cor_texto_secundario);
+  text-align: center;
+  font-weight: 300;
+}
+
+@media (max-width: 768px) {
+  .container { padding: 15px; }
+  .grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 480px) {
+  h1 { font-size: 1.4em; }
+  .container { padding: 10px; }
+  .icon-large { font-size: 36px; }
+  .grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- build phone verification form with error handling and navigation
- show number analysis screen with tips and loader
- display verification results and fake spying info
- centralize styling and scripts for responsiveness

## Testing
- `ls`


------
https://chatgpt.com/codex/tasks/task_e_68420bcb52fc832b97e5491c33be5831